### PR TITLE
Toggle / status bar problem - Fix styles conflict

### DIFF
--- a/lib/GitStatusView.js
+++ b/lib/GitStatusView.js
@@ -3,7 +3,7 @@
 export default class GitStatusView {
   constructor(project) {
     this.element = document.createElement("div");
-    this.element.classList.add("git-status");
+    this.element.id = "package-git-status";
     this.element.tabIndex = -1;
   }
 

--- a/styles/git-status.less
+++ b/styles/git-status.less
@@ -1,44 +1,44 @@
 @import "ui-variables";
 
-.git-status {
-  padding: 0.5em 1em;
-  max-height: 12.5em;
-  overflow-y: auto;
-}
+#package-git-status {
+    padding: 0.5em 1em;
+    max-height: 12.5em;
+    overflow-y: auto;
 
-.git-status-empty {
-    font-size: 1.2em;
-}
+    .git-status-empty {
+        font-size: 1.2em;
+    }
 
-.git-status-item {
-  margin: 0.35em 0;
-}
+    .git-status-item {
+      margin: 0.35em 0;
+    }
 
-.git-status-item:first-child {
-  margin-top: 0;
-}
+    .git-status-item:first-child {
+      margin-top: 0;
+    }
 
-.git-status-item:last-child {
-  margin-bottom: 0;
-}
+    .git-status-item:last-child {
+      margin-bottom: 0;
+    }
 
-.git-status-item:hover:not(.deleted) {
-  text-decoration: underline;
-  cursor: pointer;
-}
+    .git-status-item:hover:not(.deleted) {
+      text-decoration: underline;
+      cursor: pointer;
+    }
 
-.git-status-item.untracked {
-  color: @text-color-subtle;
-}
+    .git-status-item.untracked {
+      color: @text-color-subtle;
+    }
 
-.git-status-item.added {
-  color: @text-color-success;
-}
+    .git-status-item.added {
+      color: @text-color-success;
+    }
 
-.git-status-item.modified {
-  color: @text-color-warning;
-}
+    .git-status-item.modified {
+      color: @text-color-warning;
+    }
 
-.git-status-item.deleted {
-  color: @text-color-error;
+    .git-status-item.deleted {
+      color: @text-color-error;
+    }
 }


### PR DESCRIPTION
When git-status is toggled, the status bar on the right side is little lower ... It's visible on your screenshot  in README too :)

My screenshot:
[![https://gyazo.com/3262ba31ba8b0b365231caaabc514625](https://i.gyazo.com/3262ba31ba8b0b365231caaabc514625.png)](https://gyazo.com/3262ba31ba8b0b365231caaabc514625)

I think the problem is because you use "git-status" class.. same class as in status bar. I changed class to unique id.
